### PR TITLE
Fix branch name display: nested namespaces + smart truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,8 @@
 # Claude Code Productivity Statusline
 
-A productivity-focused statusline for [Claude Code](https://code.claude.com/docs/en/statusline) that displays coding metrics, performance statistics, and development context.
+A productivity-focused statusline for [Claude Code](https://code.claude.com/docs/en/statusline) that displays coding metrics, performance stats, and development context.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Python 3.7+](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/)
-
-## Overview
-
-This statusline transforms Claude Code's status bar into a developer productivity dashboard, showing real-time metrics that matter for coding: code changes, API performance, cost tracking, and git status.
-
-## Quick Start
-
-```bash
-# 1. Copy the script
-cp statusline-hz.py ~/.claude/
-
-# 2. Make it executable
-chmod +x ~/.claude/statusline-hz.py
-
-# 3. Configure Claude Code (see Configuration section)
-
-# 4. Restart Claude Code
-```
 
 ## Example Output
 
@@ -29,69 +10,35 @@ chmod +x ~/.claude/statusline-hz.py
 [N] ⏰ 14:30 Sonnet 4.5 statusline:main*2 +1 | $0.125 5m [━━━━──────] 42% 57k/200k | 📝 +127/-43 ↗ | ⚡5.0s
 ```
 
-**Output Breakdown:**
-
 | Element | Description |
 |---------|-------------|
-| `[N]` | Vim mode indicator (N=Normal, I=Insert, V=Visual, R=Replace) |
+| `[N]` | Vim mode (N/I/V/R/C) |
 | `⏰ 14:30` | Current time |
-| `Sonnet 4.5` | AI model name (color: orange), with output style if set |
-| `statusline:main*2 +1` | Directory:branch with 2 uncommitted files, 1 commit ahead of upstream |
-| `$0.125 5m [━━━━──────] 42% 57k/200k` | Session cost, duration, visual context window bar with token usage |
-| `📝 +127/-43 ↗` | Lines added/removed with trend arrow (color: green) |
-| `⚡5.0s` | Cumulative API time (color-coded by session length) |
+| `Sonnet 4.5` | Model name (with output style if set) |
+| `statusline:main*2 +1` | Directory:branch — 2 dirty files, 1 commit ahead |
+| `$0.125 5m [━━━━──────] 42% 57k/200k` | Cost, duration, visual context bar, token usage |
+| `📝 +127/-43 ↗` | Lines added/removed with trend arrow |
+| `⚡5.0s` | Cumulative API time |
 
 ## Features
 
-### Core Metrics
-
-- **Code Change Statistics** - Real-time tracking of lines added/removed
-- **API Performance Monitoring** - Response time with color-coded indicators
-- **Cost Tracking** - Session cost with configurable threshold alerts
-- **Session Duration** - Time spent in current session (shows seconds if < 1 minute)
-- **Git Status** - Branch name with uncommitted changes indicator
-
-### Advanced Features
-
-- **Vim Mode Indicator** - Shows current vim mode `[N]`/`[I]`/`[V]`/`[R]`/`[C]` with per-mode colors
-- **Visual Context Window Bar** - Progress bar `[━━━━──────] 42% 57k/200k` with 3-level color thresholds (green/yellow/red); uses Box Drawing glyphs for safe CJK font rendering; legacy `ctx:42%` text mode also available
-- **Git Detail** - Uncommitted file count + upstream ahead/behind indicators (`main*3 +2 -1`; Nerd Font mode renders `main●3 ↑2 ↓1`)
-- **Theme System** - Built-in palettes: `default`, `gruvbox`, `nord`, `minimal` (env switch)
-- **Nerd Font Icons** - Optional Nerd Font glyph mode in addition to plain emoji icons
-- **Custom Model Aliases** - Map model id/display name to a short label via JSON env var
-- **Token Count Display** - Optional `tok:45.0K/12.0K` input/output token counts
-- **Cost Burn Rate** - Optional per-minute cost rate `(0.05/m)`
-- **Output Style Display** - Shows active output style next to model name
-- **200K+ Token Warning** - Alert when session exceeds 200K tokens
-- **Configurable Layout** - Customize segment order via `STATUSLINE_LAYOUT` environment variable
-- **Trend Analysis** - Compare current session with previous (`↗` increased, `→` similar, `↘` decreased, `(new)` first session)
-- **Cost Alerts** - Warning emoji `⚠️` when cost exceeds threshold
-- **Smart Color Coding** - Visual hierarchy for quick information parsing
-- **Cross-platform Support** - Works on macOS, Linux, and Windows (fcntl/msvcrt file locking)
-- **Graceful Degradation** - Works even without git or with invalid configuration
-- **Detached HEAD Support** - Shows short commit hash with `@` prefix when not on a branch
-- **Git Status Caching** - 5-second cache for performance optimization
-- **File Locking** - Safe concurrent access for multi-instance usage
-
-## Requirements
-
-- **Python**: 3.7 or higher
-- **Claude Code**: Latest version (tested on v1.2.0+)
-- **Git** (optional): For branch and dirty status display
-- **Dependencies**: Standard library only (no external packages required)
+- **Productivity metrics** — line changes, API time, session cost, duration, trend arrows
+- **Visual context bar** — `[━━━━──────] 42% 57k/200k` with green/yellow/red thresholds (CJK-safe Box Drawing glyphs)
+- **Git integration** — branch (with smart truncation), dirty count, ahead/behind, detached HEAD
+- **Vim mode indicator** — per-mode colors
+- **Themes** — `default`, `gruvbox`, `nord`, `minimal`
+- **Nerd Font icons** — optional glyph mode
+- **Configurable layout** — segment order via env var
+- **Zero dependencies** — Python stdlib only
 
 ## Installation
-
-### Step 1: Copy Script
 
 ```bash
 cp statusline-hz.py ~/.claude/
 chmod +x ~/.claude/statusline-hz.py
 ```
 
-### Step 2: Configure Claude Code
-
-Edit your `.claude/settings.json`:
+Then edit `~/.claude/settings.json`:
 
 ```json
 {
@@ -99,44 +46,33 @@ Edit your `.claude/settings.json`:
     "type": "command",
     "command": "~/.claude/statusline-hz.py",
     "padding": 0
-  },
-  "env": {
-    "STATUSLINE_COST_THRESHOLD": "0.50",
-    "STATUSLINE_LOG_LEVEL": "WARNING",
-    "STATUSLINE_DEBUG": "0",
-    "STATUSLINE_SHOW_TOKENS": "0",
-    "STATUSLINE_SHOW_BURNRATE": "0",
-    "STATUSLINE_LAYOUT": "vim,time,model,dir,cost,lines,api"
   }
 }
 ```
 
-### Step 3: Restart Claude Code
-
-The statusline will appear at the bottom of your Claude Code interface.
+Restart Claude Code. **Requirements:** Python 3.9+, Claude Code v1.2.0+.
 
 ## Configuration
 
-### Environment Variables
+All configuration is via environment variables in `settings.json` → `env`.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `STATUSLINE_COST_THRESHOLD` | float | `0.50` | USD threshold for cost alerts |
-| `STATUSLINE_LOG_LEVEL` | string | `WARNING` | Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL, OFF) |
-| `STATUSLINE_DEBUG` | boolean | `0` | Enable debug mode (0 or 1) |
-| `STATUSLINE_SHOW_TOKENS` | boolean | `0` | Show input/output token counts |
-| `STATUSLINE_SHOW_BURNRATE` | boolean | `0` | Show cost burn rate per minute |
 | `STATUSLINE_LAYOUT` | string | `vim,time,model,dir,cost,lines,api` | Comma-separated segment order |
-| `STATUSLINE_THEME` | string | `default` | Color palette: `default`, `gruvbox`, `nord`, `minimal` |
-| `STATUSLINE_ICON_MODE` | string | `plain` | Icon set: `plain` (emoji) or `nerd_font` (Nerd Font glyphs) |
-| `STATUSLINE_CTX_STYLE` | string | `bar` | Context window style: `bar` (visual) or `text` (legacy `ctx:42%`) |
-| `STATUSLINE_GIT_DETAIL` | string | `full` | Git indicator: `full` (count+ahead/behind), `simple` (dot only), `off` |
-| `STATUSLINE_MODEL_ALIASES` | JSON | `{}` | Model id/name → display alias, e.g. `{"claude-opus-4-6":"O4.6"}` |
-| `NO_COLOR` | any | - | Disable color output (standard) |
+| `STATUSLINE_THEME` | string | `default` | Palette: `default`, `gruvbox`, `nord`, `minimal` |
+| `STATUSLINE_ICON_MODE` | string | `plain` | `plain` (emoji+ASCII) or `nerd_font` (glyphs) |
+| `STATUSLINE_CTX_STYLE` | string | `bar` | Context display: `bar` or `text` (legacy `ctx:42%`) |
+| `STATUSLINE_GIT_DETAIL` | string | `full` | `full` (count+ahead/behind), `simple` (dot only), `off` |
+| `STATUSLINE_BRANCH_MAX_LEN` | int | `25` | Max branch name length; `0` disables truncation |
+| `STATUSLINE_COST_THRESHOLD` | float | `0.50` | USD threshold for cost alerts |
+| `STATUSLINE_MODEL_ALIASES` | JSON | `{}` | Model id/name → short label, e.g. `{"claude-opus-4-6":"O4.6"}` |
+| `STATUSLINE_SHOW_TOKENS` | bool | `0` | Show input/output token counts |
+| `STATUSLINE_SHOW_BURNRATE` | bool | `0` | Show per-minute cost rate |
+| `STATUSLINE_LOG_LEVEL` | string | `WARNING` | `DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`/`OFF` |
+| `STATUSLINE_DEBUG` | bool | `0` | Enable debug mode |
+| `NO_COLOR` | any | – | Standard: disable all colors (always wins) |
 
-### Layout System
-
-The `STATUSLINE_LAYOUT` environment variable controls which segments appear and in what order. Available segments:
+### Layout Segments
 
 | Segment | Description |
 |---------|-------------|
@@ -145,210 +81,86 @@ The `STATUSLINE_LAYOUT` environment variable controls which segments appear and 
 | `model` | Model name (with output style) |
 | `dir` | Directory and git branch |
 | `cost` | Cost, duration, and context window |
-| `context` | Standalone context window (skipped when `cost` is in layout) |
+| `context` | Standalone context (skipped when `cost` present) |
 | `tokens` | Token counts (requires `STATUSLINE_SHOW_TOKENS=1`) |
 | `lines` | Code change statistics with trend |
 | `api` | API performance time |
 | `burnrate` | Cost burn rate (requires `STATUSLINE_SHOW_BURNRATE=1`) |
 
-Header segments (`vim`, `time`, `model`, `dir`) are joined with spaces. All other segments are separated by ` | `.
+Header segments (`vim`, `time`, `model`, `dir`) join with spaces; the rest are separated by ` | `.
 
-### Performance Indicators
+## Visual Reference
 
-#### Context Window Usage Colors
+### Context Window (3-tier)
 
 | Color | Range | Meaning |
 |-------|-------|---------|
-| 🟢 Green | < 50% | Plenty of context remaining |
-| 🟡 Yellow | 50% - 75% | Context getting used up |
-| 🔴 Red | ≥ 75% | Context nearly full |
+| 🟢 Green | < 50% | Plenty remaining |
+| 🟡 Yellow | 50–75% | Getting used up |
+| 🔴 Red | ≥ 75% | Nearly full |
 
-The default visual bar `[━━━━──────] 42% 57k/200k` uses Box Drawing
-characters (`━` filled, `─` empty), which are unambiguously narrow in
-all CJK fonts. Each cell represents 10%, rounded half-up. Set
-`STATUSLINE_CTX_STYLE=text` to fall back to the legacy `ctx:42%` format.
+Each cell of `[━━━━──────]` represents 10% (rounded half-up).
 
-#### Themes
+### API Time (cumulative per session)
 
-Switch with `STATUSLINE_THEME=<name>`:
-
-| Theme | Style |
+| Color | Range |
 |-------|-------|
-| `default` | Eye-friendly muted palette (current) |
-| `gruvbox` | Warm retro |
-| `nord` | Cool arctic |
-| `minimal` | Mostly grayscale, only red for alerts |
+| 🟢 Green | < 10s |
+| 🟡 Yellow | 10–60s |
+| 🔴 Red | > 60s |
 
-`NO_COLOR=1` always wins and disables all colors.
-
-#### Git Detail Modes
-
-`STATUSLINE_GIT_DETAIL`:
-
-| Mode | Output |
-|------|--------|
-| `full` (default) | `main*3 +2 -1` — file count, commits ahead, commits behind (ASCII; `STATUSLINE_ICON_MODE=nerd_font` switches to `●3 ↑2 ↓1`) |
-| `simple` | `main*` — single dirty marker only |
-| `off` | `main` — no indicators |
-
-#### Cumulative API Time Colors
-
-The API time shown is the **cumulative** time spent on API calls during the session:
-
-| Color | Range | Meaning |
-|-------|-------|---------|
-| 🟢 Green | < 10s | Fast session, minimal API usage |
-| 🟡 Yellow | 10s - 60s | Normal session, moderate API usage |
-| 🔴 Red | > 60s | Long session, significant API usage |
-
-#### Vim Mode Colors
+### Vim Modes
 
 | Mode | Indicator | Color |
 |------|-----------|-------|
-| Normal | `[N]` | 🟢 Green |
-| Insert | `[I]` | 🟡 Yellow |
-| Visual | `[V]` | 🔵 Cyan |
-| Replace | `[R]` | 🔴 Red |
+| Normal | `[N]` | Green |
+| Insert | `[I]` | Yellow |
+| Visual | `[V]` | Cyan |
+| Replace | `[R]` | Red |
 | Command | `[C]` | Dim |
 
-#### Trend Arrows
+### Git Detail Modes
 
-| Arrow | Meaning |
-|-------|---------|
-| `(new)` | First session (no previous data to compare) |
-| `↗` | Activity increased (>20% more changes) |
-| `→` | Similar activity level (±20%) |
-| `↘` | Activity decreased (>20% fewer changes) |
+| Mode | Output |
+|------|--------|
+| `full` (default) | `main*3 +2 -1` (ASCII) or `main●3 ↑2 ↓1` (nerd_font) |
+| `simple` | `main*` |
+| `off` | `main` |
 
-## Design Philosophy
+### Trend Arrows
 
-This statusline prioritizes **developer productivity** by displaying actionable metrics:
-
-- **Code Productivity** - Track actual work output with line change statistics
-- **Performance Awareness** - Monitor API response times to identify slowdowns
-- **Cost Management** - Stay within budget with real-time cost tracking
-- **Development Context** - Git branch and status at a glance
-
-All metrics are derived from Claude Code's built-in session data, requiring no external APIs or dependencies.
-
-## Data Sources
-
-The statusline extracts data from Claude Code's session context (passed via stdin):
-
-| Metric | Source Field |
-|--------|--------------|
-| Lines Added | `cost.total_lines_added` |
-| Lines Removed | `cost.total_lines_removed` |
-| API Duration | `cost.total_api_duration_ms` |
-| Session Cost | `cost.total_cost_usd` |
-| Session Duration | `cost.total_duration_ms` |
-| Working Directory | `workspace.current_dir` |
-| AI Model | `model.display_name` |
-| Context Window | `context_window.used_percentage` |
-| Context Size | `context_window.context_window_size` |
-| Input Tokens | `context_window.total_input_tokens` |
-| Output Tokens | `context_window.total_output_tokens` |
-| 200K+ Flag | `exceeds_200k_tokens` |
-| Vim Mode | `vim.mode` |
-| Output Style | `output_style.name` |
+`(new)` first session · `↗` >20% more · `→` ±20% similar · `↘` >20% fewer.
 
 ## Troubleshooting
 
-### No metrics showing?
+| Symptom | Check |
+|---------|-------|
+| No metrics | Claude Code v1.2.0+, cost tracking enabled, logs in `~/.cache/claude-statusline/logs/` |
+| Glyphs misaligned | Switch `STATUSLINE_ICON_MODE=plain` (CJK font width issue) |
+| Trends missing | Need ≥2 sessions; cache: `~/.cache/claude-statusline/session_stats.json` (24h TTL) |
+| Branch wrong | `STATUSLINE_BRANCH_MAX_LEN=0` to disable truncation |
 
-- Ensure you're using Claude Code v1.2.0 or higher
-- Verify cost tracking is enabled in Claude Code
-- Check logs: `~/.cache/claude-statusline/logs/`
-
-### Colors not working?
-
-- Check if `NO_COLOR` environment variable is set
-- Enable debug mode: `STATUSLINE_DEBUG=1`
-- Verify terminal supports ANSI colors
-
-### Trend arrows not appearing?
-
-- Arrows require at least two sessions for comparison
-- Cache location: `~/.cache/claude-statusline/session_stats.json`
-- Cache lifetime: 24 hours
-
-### Git dirty status not showing?
-
-- Ensure `git` is installed and in PATH
-- Check that working directory is a git repository
-- Verify git permissions
-
-### Invalid configuration values?
-
-The statusline gracefully handles invalid configuration:
-- Invalid `STATUSLINE_COST_THRESHOLD` → defaults to `0.50`
-- Invalid `STATUSLINE_LOG_LEVEL` → defaults to `WARNING`
-- Missing cache directory → continues without trend tracking
+Invalid env values silently fall back to defaults — the statusline never crashes the host shell.
 
 ## Development
 
-### Testing Locally
-
 ```bash
-# Test with mock data
-echo '{
-  "model": {"display_name": "Sonnet 4.5"},
-  "workspace": {"current_dir": "/path/to/project"},
-  "cost": {
-    "total_cost_usd": 0.125,
-    "total_duration_ms": 300000,
-    "total_lines_added": 127,
-    "total_lines_removed": 43,
-    "total_api_duration_ms": 5000
-  },
-  "context_window": {
-    "used_percentage": 42.5,
-    "remaining_percentage": 57.5,
-    "total_input_tokens": 45000,
-    "total_output_tokens": 12000
-  },
-  "vim": {"mode": "normal"},
-  "output_style": {"name": "concise"}
-}' | python3 statusline-hz.py
-```
-
-### Running Unit Tests
-
-```bash
-# Run all tests
+# Run tests
 python3 tests/test_statusline.py -v
 
-# Or with pytest (if installed)
-pytest tests/test_statusline.py -v
+# Smoke test with mock data
+echo '{"workspace":{"current_dir":"."},"model":{"display_name":"Sonnet 4.5"},"cost":{"total_cost_usd":0.125,"total_duration_ms":300000,"total_lines_added":127,"total_lines_removed":43,"total_api_duration_ms":5000}}' | python3 statusline-hz.py
+
+# Debug mode
+STATUSLINE_LOG_LEVEL=DEBUG STATUSLINE_DEBUG=1 python3 statusline-hz.py
 ```
 
-### Enable Debug Logging
-
-```bash
-export STATUSLINE_LOG_LEVEL=DEBUG
-export STATUSLINE_DEBUG=1
-```
-
-Logs are written to: `~/.cache/claude-statusline/logs/statusline-YYYYMMDD.log`
-
-### Performance Notes
-
-According to [Claude Code official documentation](https://code.claude.com/docs/en/statusline):
-- Statusline updates are throttled to every 300ms
-- Git status checks are cached for 5 seconds to stay within this budget
-- Log cleanup runs once per day to minimize I/O overhead
+Logs: `~/.cache/claude-statusline/logs/statusline-YYYYMMDD.log`
 
 ## License
 
-MIT License - See [LICENSE](LICENSE) file for details.
-
-## Acknowledgments
-
-Built with insights from:
-- [Claude Code Official Documentation](https://code.claude.com/docs/en/statusline)
-- Terminal statusline best practices
-- Developer productivity metrics research
+MIT — see [LICENSE](LICENSE).
 
 ---
 
-**Note**: This is an independent project and is not officially affiliated with Anthropic or Claude Code.
+*Independent project, not affiliated with Anthropic.*

--- a/statusline-hz.py
+++ b/statusline-hz.py
@@ -105,20 +105,24 @@ ICONS: Dict[str, Dict[str, str]] = {
     # advance only 1, causing the digit suffix to overdraw the glyph).
     # Emoji (⏰📝⚡) are fullwidth and handled correctly by terminals.
     'plain': {
-        'time':   '⏰',
-        'lines':  '📝',
-        'api':    '⚡',
-        'dirty':  '*',
-        'ahead':  '+',
-        'behind': '-',
+        'time':     '⏰',
+        'lines':    '📝',
+        'api':      '⚡',
+        'dirty':    '*',
+        'ahead':    '+',
+        'behind':   '-',
+        # ASCII fallback: U+2026 (…) is East Asian Ambiguous and overdraws
+        # under CJK fonts, same root cause as the dirty/ahead/behind glyphs.
+        'ellipsis': '..',
     },
     'nerd_font': {
-        'time':   '\uf017',
-        'lines':  '\uf044',
-        'api':    '\uf0e7',
-        'dirty':  '\uf444',
-        'ahead':  '↑',
-        'behind': '↓',
+        'time':     '\uf017',
+        'lines':    '\uf044',
+        'api':      '\uf0e7',
+        'dirty':    '\uf444',
+        'ahead':    '↑',
+        'behind':   '↓',
+        'ellipsis': '…',
     },
 }
 DEFAULT_ICON_MODE = 'plain'
@@ -133,6 +137,12 @@ GIT_DETAIL_FULL = 'full'
 GIT_DETAIL_SIMPLE = 'simple'
 GIT_DETAIL_OFF = 'off'
 DEFAULT_GIT_DETAIL = GIT_DETAIL_FULL
+
+# Branch name display
+# 25 matches Oh My Posh's common preset; long enough for typical
+# `feature/short-name` patterns, short enough to keep the bar compact.
+# Set to 0 (or any value <= 0) to disable truncation entirely.
+DEFAULT_BRANCH_MAX_LEN = 25
 
 # Visual context bar cell thresholds (cell width is 100/CTX_BAR_WIDTH = 10%)
 
@@ -223,6 +233,13 @@ class Config:
         self.icon_mode = _env_choice('STATUSLINE_ICON_MODE', DEFAULT_ICON_MODE, self.VALID_ICON_MODES)
         self.ctx_style = _env_choice('STATUSLINE_CTX_STYLE', DEFAULT_CTX_STYLE, self.VALID_CTX_STYLES)
         self.git_detail = _env_choice('STATUSLINE_GIT_DETAIL', DEFAULT_GIT_DETAIL, self.VALID_GIT_DETAILS)
+
+        # Branch name max length: integer >= 0; <= 0 disables truncation.
+        # Invalid values silently fall back to the default.
+        try:
+            self.branch_max_len = int(os.environ.get('STATUSLINE_BRANCH_MAX_LEN', DEFAULT_BRANCH_MAX_LEN))
+        except (ValueError, TypeError):
+            self.branch_max_len = DEFAULT_BRANCH_MAX_LEN
 
         self.model_aliases = self._parse_model_aliases()
 
@@ -602,8 +619,13 @@ def parse_claude_context(model_aliases: Optional[Dict[str, str]] = None) -> Clau
                     try:
                         content = git_head.read_text().strip()
                         if content.startswith('ref: '):
-                            # Normal branch reference
-                            ctx.branch = content.split('/')[-1]
+                            # Strip both prefixes individually: splitting on
+                            # '/' would silently drop nested namespaces such
+                            # as `feature/foo/bar`, mangling the display name.
+                            ctx.branch = (
+                                content.removeprefix('ref: ')
+                                       .removeprefix('refs/heads/')
+                            )
                         else:
                             # Detached HEAD - show short commit hash
                             ctx.branch = content[:7]
@@ -715,16 +737,31 @@ def _build_model_segment(ctx: ClaudeContext) -> str:
     return model_str
 
 
+def _truncate_branch(name: str, max_len: int, ellipsis: str) -> str:
+    """Right-truncate `name` to `max_len` chars and append `ellipsis`.
+
+    `max_len <= 0` disables truncation. The ellipsis is appended *after*
+    `max_len` chars so the visible width stays predictable across icon modes.
+    """
+    if max_len <= 0 or len(name) <= max_len:
+        return name
+    return name[:max_len] + ellipsis
+
+
 def _build_dir_segment(ctx: ClaudeContext, git_status: GitStatus, config: Config) -> str:
     """Build directory and branch segment with git indicators."""
     segment = f"{Colors.DIM}{ctx.dir}{Colors.RESET}"
     if not ctx.branch:
         return segment
 
+    branch_display = _truncate_branch(
+        ctx.branch, config.branch_max_len, config.icons['ellipsis']
+    )
+
     if ctx.detached:
-        segment += f":{Colors.DIM}@{ctx.branch}{Colors.RESET}"
+        segment += f":{Colors.DIM}@{branch_display}{Colors.RESET}"
     else:
-        segment += f":{ctx.branch}"
+        segment += f":{branch_display}"
 
     detail = config.git_detail
     if detail == GIT_DETAIL_OFF:

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -773,6 +773,62 @@ class TestGitDetail(unittest.TestCase):
         self.assertNotIn('-', result)
 
 
+class TestBranchTruncation(unittest.TestCase):
+    """Test branch name truncation (STATUSLINE_BRANCH_MAX_LEN)."""
+
+    BASE_ENV = {'STATUSLINE_GIT_DETAIL': 'off', 'NO_COLOR': '1'}
+
+    def _render(self, branch, env=None, detached=False):
+        merged = {**self.BASE_ENV, **(env or {})}
+        with patch.dict(os.environ, merged):
+            config = statusline.Config()
+        ctx = statusline.ClaudeContext(dir='proj', branch=branch, detached=detached)
+        return statusline._build_dir_segment(ctx, statusline.GitStatus(), config)
+
+    def test_truncate_pure_helper(self):
+        cases = [
+            ('within limit',  ('main',     25, '..'), 'main'),
+            ('exact length',  ('a' * 25,   25, '..'), 'a' * 25),
+            ('overflow',      ('a' * 30,   10, '..'), 'a' * 10 + '..'),
+            ('disabled (0)',  ('a' * 100,   0, '..'), 'a' * 100),
+            ('disabled (-1)', ('a' * 100,  -1, '..'), 'a' * 100),
+        ]
+        for label, args, expected in cases:
+            with self.subTest(label):
+                self.assertEqual(statusline._truncate_branch(*args), expected)
+
+    def test_default_truncates_long_branch_in_segment(self):
+        result = self._render('visual-context-bar-and-git-detail')  # 32 chars
+        self.assertIn('visual-context-bar-and-gi..', result)
+        self.assertNotIn('git-detail', result)
+
+    def test_disable_via_env(self):
+        result = self._render(
+            'visual-context-bar-and-git-detail',
+            env={'STATUSLINE_BRANCH_MAX_LEN': '0'},
+        )
+        self.assertIn('visual-context-bar-and-git-detail', result)
+
+    def test_invalid_env_falls_back_to_default(self):
+        with patch.dict(os.environ, {'STATUSLINE_BRANCH_MAX_LEN': 'not-an-int'}):
+            config = statusline.Config()
+        self.assertEqual(config.branch_max_len, statusline.DEFAULT_BRANCH_MAX_LEN)
+
+    def test_nerd_font_uses_unicode_ellipsis(self):
+        result = self._render('abcdefghij', env={
+            'STATUSLINE_ICON_MODE': 'nerd_font',
+            'STATUSLINE_BRANCH_MAX_LEN': '5',
+        })
+        self.assertIn('abcde…', result)
+
+    def test_detached_head_truncated_uniformly(self):
+        # Detached HEAD must flow through the same truncation path as branches
+        # so abstraction boundaries don't leak across the two display modes.
+        result = self._render('abc1234', env={'STATUSLINE_BRANCH_MAX_LEN': '4'},
+                              detached=True)
+        self.assertIn('@abc1..', result)
+
+
 class TestCrossPlatformLocking(unittest.TestCase):
     """Test cross-platform file locking functions"""
 


### PR DESCRIPTION
## Summary

- **Bug fix**: branch names with nested namespaces (e.g. `feature/foo/bar`) were silently mangled to just `bar` because the parser used `split('/')[-1]`. Now strips the `refs/heads/` prefix properly via `str.removeprefix`.
- **New feature**: `STATUSLINE_BRANCH_MAX_LEN` (default `25`) right-truncates long branch names with `..` (plain) or `…` (nerd_font). Mirrors Starship / Powerlevel10k / Oh My Posh conventions. Set to `0` to disable.
- **Docs cleanup**: README trimmed from 356 → 166 lines (-53%) by removing duplicated Quick Start, marketing-style Design Philosophy, internal Data Sources field map, Acknowledgments filler, and 8 implementation-detail "features". Merged color/mode tables under a single Visual Reference section.

## Why

The current branch on this very repo is `feature/visual-context-bar-and-git-detail` (32 chars). On a long-namespace branch the statusline either lost information (nested namespaces) or pushed downstream segments off-screen. This addresses both.

## Test plan

- [x] All 115 unit tests pass (`python3 -m unittest tests.test_statusline`)
- [x] New `TestBranchTruncation` class covers: pure helper edge cases (subTest-parameterized), default truncation, env disable, invalid env fallback, nerd_font ellipsis, detached HEAD path
- [x] End-to-end smoke test on this repo's branch confirms the fix:
  - Before: `statusline:visual-context-bar-and-git-detail` (32 chars, lost `feature/` namespace)
  - After: `statusline:feature/visual-context-ba..` (25 chars + `..`, namespace preserved)
- [x] Verified with `STATUSLINE_BRANCH_MAX_LEN=0` (disabled), `=10` (short), `=40` (long)
- [x] Verified `nerd_font` icon mode uses `…`, `plain` uses `..` (CJK-safe ASCII fallback consistent with prior fix)

## Notes

- Uses `str.removeprefix` (Python 3.9+); README updated to reflect actual minimum version (was previously claiming 3.7+).
- Branch parsing also benefits from a `/simplify` pass: removed narrative comments, merged 5 over-tested pure helper cases into one `subTest` table, extracted `_render` test helper to deduplicate env var boilerplate.